### PR TITLE
4x Faster BlurHash decoding with optimized algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,33 @@ class BlurHashApp extends StatelessWidget {
 ```
 
 
+
+## Optimization Modes
+
+- **None** (BlurHashOptimizationMode.none): The original algorithm, provided for backward compatibility.
+- **Standard** (BlurHashOptimizationMode.standard): Optimized decoding with better cache locality and performance.
+- **Approximation** (BlurHashOptimizationMode.approximation): Fastest mode with an approximated sRGB conversion that produces slightly darker results but significantly improves performance.
+
+```dart
+class BlurHashApp extends StatelessWidget {
+  const BlurHashApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) => MaterialApp(
+    home: Scaffold(
+      appBar: AppBar(title: const Text("BlurHash")),
+      body: const SizedBox.expand(
+        child: Center(
+          child: AspectRatio(
+            aspectRatio: 1.6,
+            child: BlurHash(
+              hash: "L5H2EC=PM+yV0g-mq.wG9c010J}I",
+              optimizationMode: BlurHashOptimizationMode.approximation,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+```

--- a/lib/src/blurhash.dart
+++ b/lib/src/blurhash.dart
@@ -4,12 +4,25 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 
+/// Optimization modes for BlurHash decoder
+enum BlurHashOptimizationMode {
+  /// Original algorithm
+  none,
+
+  /// Optimized with better cache locality
+  standard,
+
+  /// Approximation with faster sRGB conversion + cache locality
+  approximation
+}
+
 // Optimized BlurHash decode implementation
 Future<Uint8List> optimizedBlurHashDecode({
   required String blurHash,
   required int width,
   required int height,
   double punch = 1.0,
+  BlurHashOptimizationMode optimizationMode = BlurHashOptimizationMode.standard,
 }) {
   _validateBlurHash(blurHash);
 
@@ -56,38 +69,49 @@ Future<Uint8List> optimizedBlurHashDecode({
 
   // Process image in chunks to improve cache locality
   const chunkSize = 32;
-  
+
   // Process the image in tiles for better cache performance
   for (int yChunk = 0; yChunk < height; yChunk += chunkSize) {
     final yEnd = min(yChunk + chunkSize, height);
-    
+
     for (int xChunk = 0; xChunk < width; xChunk += chunkSize) {
       final xEnd = min(xChunk + chunkSize, width);
-      
+
       for (int y = yChunk; y < yEnd; y++) {
         int p = (y * width + xChunk) * 4;
-        
+
         for (int x = xChunk; x < xEnd; x++) {
           var r = 0.0, g = 0.0, b = 0.0;
-          
+
           // Use precalculated cosine values
           for (int j = 0; j < numY; j++) {
             final cosY = cosinesY[j][y];
-            
+
             for (int i = 0; i < numX; i++) {
               final basis = cosinesX[i][x] * cosY;
               final color = colors[i + j * numX];
-              
+
               r += color[0] * basis;
               g += color[1] * basis;
               b += color[2] * basis;
             }
           }
 
-          // Convert linear RGB to sRGB space
-          pixels[p++] = _optimizedLinearTosRGB(r);
-          pixels[p++] = _optimizedLinearTosRGB(g);
-          pixels[p++] = _optimizedLinearTosRGB(b);
+          // Convert linear RGB to sRGB space based on optimization mode
+          switch (optimizationMode) {
+            case BlurHashOptimizationMode.approximation:
+              pixels[p++] = _approximatedLinearTosRGB(r);
+              pixels[p++] = _approximatedLinearTosRGB(g);
+              pixels[p++] = _approximatedLinearTosRGB(b);
+              break;
+            case BlurHashOptimizationMode.standard:
+            case BlurHashOptimizationMode.none:
+              pixels[p++] = _linearTosRGB(r);
+              pixels[p++] = _linearTosRGB(g);
+              pixels[p++] = _linearTosRGB(b);
+              break;
+          }
+
           pixels[p++] = 255; // Alpha is always 255
         }
       }
@@ -97,9 +121,11 @@ Future<Uint8List> optimizedBlurHashDecode({
   return Future.value(pixels);
 }
 
-int _optimizedLinearTosRGB(double value) {
+/// Approximated version using square roots for faster computation
+/// This will produce slightly different (darker) results but is faster
+int _approximatedLinearTosRGB(double value) {
   final v = max(0.0, min(1.0, value));
-  
+
   if (v <= 0.0031308) {
     return (v * 12.92 * 255 + 0.5).toInt();
   } else {
@@ -176,24 +202,35 @@ Future<ui.Image> blurHashDecodeImage({
   required int width,
   required int height,
   double punch = 1.0,
-  bool useOptimized = false,
+  BlurHashOptimizationMode optimizationMode = BlurHashOptimizationMode.standard,
 }) async {
   _validateBlurHash(blurHash);
 
   final completer = Completer<ui.Image>();
-  final decoder = useOptimized ? optimizedBlurHashDecode : blurHashDecode;
+
+  final Uint8List pixels;
+  if (optimizationMode != BlurHashOptimizationMode.none) {
+    pixels = await optimizedBlurHashDecode(
+      blurHash: blurHash,
+      width: width,
+      height: height,
+      punch: punch,
+      optimizationMode: optimizationMode,
+    );
+  } else {
+    pixels = await blurHashDecode(
+      blurHash: blurHash,
+      width: width,
+      height: height,
+      punch: punch,
+    );
+  }
 
   if (kIsWeb) {
-    // https://github.com/flutter/flutter/issues/45190
-    final pixels = await decoder(
-        blurHash: blurHash, width: width, height: height, punch: punch);
     completer.complete(_createBmp(pixels, width, height));
   } else {
-    decoder(blurHash: blurHash, width: width, height: height, punch: punch)
-        .then((pixels) {
-      ui.decodeImageFromPixels(
-          pixels, width, height, ui.PixelFormat.rgba8888, completer.complete);
-    });
+    ui.decodeImageFromPixels(
+        pixels, width, height, ui.PixelFormat.rgba8888, completer.complete);
   }
 
   return completer.future;
@@ -319,24 +356,3 @@ bool validateBlurhash(String blurhash) {
 
 const _digitCharacters =
     "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz#\$%*+,-.:;=?@[]^_{|}~";
-
-class Style {
-  final String name;
-  final List<ui.Color> colors;
-  final ui.Color? stroke;
-  final ui.Color? background;
-
-  const Style(
-      {required this.name, required this.colors, this.stroke, this.background});
-}
-
-const styles = {
-  'flourish': [
-    Style(
-      name: 'one',
-      colors: [],
-      stroke: null,
-      background: null,
-    )
-  ]
-};

--- a/lib/src/blurhash_widget.dart
+++ b/lib/src/blurhash_widget.dart
@@ -24,6 +24,7 @@ class BlurHash extends StatefulWidget {
     this.httpHeaders = const {},
     this.curve = Curves.easeOut,
     this.errorBuilder,
+    this.useOptimizedDecoder = false, // New flag for optimization
   })  : assert(decodingWidth > 0),
         assert(decodingHeight != 0),
         super(key: key);
@@ -68,6 +69,10 @@ class BlurHash extends StatefulWidget {
   /// Network image errorBuilder
   final ImageErrorWidgetBuilder? errorBuilder;
 
+  /// Whether to use the optimized BlurHash decoder
+  /// This will produce a slightly differnt end result (darker) but 4x faster
+  final bool useOptimizedDecoder;
+
   @override
   BlurHashState createState() => BlurHashState();
 }
@@ -95,7 +100,8 @@ class BlurHashState extends State<BlurHash> {
     if (widget.hash != oldWidget.hash ||
         widget.image != oldWidget.image ||
         widget.decodingWidth != oldWidget.decodingWidth ||
-        widget.decodingHeight != oldWidget.decodingHeight) {
+        widget.decodingHeight != oldWidget.decodingHeight ||
+        widget.useOptimizedDecoder != oldWidget.useOptimizedDecoder) {
       _init();
     }
   }
@@ -105,6 +111,7 @@ class BlurHashState extends State<BlurHash> {
       blurHash: widget.hash,
       width: widget.decodingWidth,
       height: widget.decodingHeight,
+      useOptimized: widget.useOptimizedDecoder,
     );
 
     _image.whenComplete(() => widget.onDecoded?.call());

--- a/lib/src/blurhash_widget.dart
+++ b/lib/src/blurhash_widget.dart
@@ -24,7 +24,7 @@ class BlurHash extends StatefulWidget {
     this.httpHeaders = const {},
     this.curve = Curves.easeOut,
     this.errorBuilder,
-    this.useOptimizedDecoder = false, // New flag for optimization
+    this.optimizationMode = BlurHashOptimizationMode.none,
   })  : assert(decodingWidth > 0),
         assert(decodingHeight != 0),
         super(key: key);
@@ -69,9 +69,8 @@ class BlurHash extends StatefulWidget {
   /// Network image errorBuilder
   final ImageErrorWidgetBuilder? errorBuilder;
 
-  /// Whether to use the optimized BlurHash decoder
-  /// This will produce a slightly differnt end result (darker) but 4x faster
-  final bool useOptimizedDecoder;
+  /// The optimization mode to use for decoding
+  final BlurHashOptimizationMode optimizationMode;
 
   @override
   BlurHashState createState() => BlurHashState();
@@ -101,7 +100,7 @@ class BlurHashState extends State<BlurHash> {
         widget.image != oldWidget.image ||
         widget.decodingWidth != oldWidget.decodingWidth ||
         widget.decodingHeight != oldWidget.decodingHeight ||
-        widget.useOptimizedDecoder != oldWidget.useOptimizedDecoder) {
+        widget.optimizationMode != oldWidget.optimizationMode) {
       _init();
     }
   }
@@ -111,7 +110,7 @@ class BlurHashState extends State<BlurHash> {
       blurHash: widget.hash,
       width: widget.decodingWidth,
       height: widget.decodingHeight,
-      useOptimized: widget.useOptimizedDecoder,
+      optimizationMode: widget.optimizationMode,
     );
 
     _image.whenComplete(() => widget.onDecoded?.call());


### PR DESCRIPTION
# Key Changes

Added a new **BlurHashOptimizationMode** enum with three options:

1. **none**: Uses the original algorithm (default to be backward compatible)
2. **standard**: Optimized with better cache locality (1.9)
3. **approximation**: Fast approximation with simplified sRGB conversion (a slightly darker tint)

standard mode does the following: 
- Improved cache locality
- Pre-calculated cosine values to avoid redundant computations

approximation mode add this:
- faster approximation method for sRGB conversion

### Migration
This change is fully backward compatible. The default **optimizationMode** for **BlurHashWidget** is set to **none**, so existing code will continue to use the original algorithm. To take advantage of the optimizations, users can set the **optimizationMode** parameter to **standard** or **approximation**.


# Mode Comparison Screenshots

## Standard Mode (Release Mode) (1.9x faster)

## Standard Mode
| Size | Screenshot |
|------------|-------------|
| 512×512 | <img src="https://github.com/user-attachments/assets/ae010c2a-7f0b-49e6-8da3-a6f46314c668" width="500" alt="Screenshot 1"> |
| 256×256 | <img src="https://github.com/user-attachments/assets/786c8586-eea3-4d10-b164-39aff2a78242" width="500" alt="Screenshot 2"> |
| 128×128 | <img src="https://github.com/user-attachments/assets/da84e264-e59c-427b-8b7b-0bd235f0784f" width="500" alt="Screenshot 3"> |
| 64×64 | <img src="https://github.com/user-attachments/assets/941fed93-def4-45ce-ad2b-b3dc3787fcbd" width="500" alt="Screenshot 4"> |

## Approximation Mode (Release Mode) (4x faster)
| Size | Screenshot |
|------------|-------------|
| 512×512 | <img src="https://github.com/user-attachments/assets/64d44561-ef53-483d-9e04-665db610e2fb" width="500" alt="Screenshot 5"> |
| 256×256 | <img src="https://github.com/user-attachments/assets/564f9d95-fb83-458f-af9d-75a10f850eea" width="500" alt="Screenshot 6"> |
| 128×128 | <img src="https://github.com/user-attachments/assets/853d05f4-acde-4cc6-be5c-36056a35f026" width="500" alt="Screenshot 7"> |
| 64×64 | <img src="https://github.com/user-attachments/assets/7a0ca30b-445b-4b93-8a66-715225857281" width="500" alt="Screenshot 8"> |



